### PR TITLE
Added param support to StreamItemInfo service

### DIFF
--- a/source/models/NdbClasses.py
+++ b/source/models/NdbClasses.py
@@ -179,7 +179,15 @@ class StreamItem(ndb.Model):
     @classmethod
     def get_all_stream_items(cls):
         return StreamItem.query().fetch()
-        
+
+    
+    
+    @classmethod
+    def get_stream_items_by_key(cls, stream_id):
+        return StreamItem.query(StreamItem.stream == ndb.Key('Stream', long(stream_id))).fetch()
+
+    
+    
     def getLatLng(self):
         if self.latitude is not None and self.longitude is not None:
             dict = {'lat':str(self.latitude), 'lng':str(self.longitude)}

--- a/source/services/Service_StreamItemInfo.py
+++ b/source/services/Service_StreamItemInfo.py
@@ -6,16 +6,28 @@ from source.models.NdbClasses import Stream
 
 
 #('/services/streamiteminfo', StreamItemInfoService)
+# or
+#('/services/streamiteminfo?streamid=5629499534213120')
 
 #Returns all stream items for all streams
 class StreamItemInfoService(BaseHandler):
     def get(self):
 
+        #If parameter of id=, then return only the items with that streams ID.
+        #Otherwise return all items.
+        
         self.set_content_text_json()
         response = []
+        
+        streamid = self.get_request_param("streamid")
+        
+        if (streamid == None) or (streamid == ''):        
+            my_stream_items = StreamItem.get_all_stream_items()
 
-        all_stream_items = StreamItem.get_all_stream_items()
-        for item in all_stream_items:
+        else:
+            my_stream_items = StreamItem.get_stream_items_by_key(long(streamid))
+        
+        for item in my_stream_items:
             dictItem = {"streamid": item.stream.id(),
                         "streamname": Stream.get_by_id(item.stream.id()).name,
                         "imageurl": item.URL,
@@ -24,7 +36,7 @@ class StreamItemInfoService(BaseHandler):
                         "lng": item.longitude}
                 
             response.append(dictItem)
-
+                
         print(response)
 
         self.write_response(json.dumps(response))


### PR DESCRIPTION
Added support to specify a single streamID in the parameters.
No parameter still returns all streamItems.

All StreamItems:
/services/streamiteminfo

StreamItems for specified streamid:
/services/streamiteminfo?streamid=5629499534213120'

